### PR TITLE
Convert letter spacing

### DIFF
--- a/docs/libraries/theme.md
+++ b/docs/libraries/theme.md
@@ -21,6 +21,24 @@ The formula for the calculation when fontSize is a valid number > 0 is `baseFont
 
 When fontsize is not a valid number > 0 then the formula is simply `baseFontSize / 10`
 
+### Function - getLetterSpacing
+
+The exported function `getLetterSpacing` will get the letter spacing value from 2 numbers and output a string font size in `rem` units. It takes 2 arguments:
+
+| argument | description | type | required | default |
+| -------- | ----------- | ---- | -------- | ------- |
+| letterSpacing | The letter spacing value to use | Number | ✗ | - |
+| fallbackLetterSpacing | The fallback letter spacing value to use | Number | ✓ | - |
+
+The numbers are taken on a 1:1 scale.
+
+```JavaScript
+getLetterSpacing(0.4, 0.6) // -> 0.4rem
+getLetterSpacing(null, 0.6) // -> 0.6rem
+getLetterSpacing(0, 0.6) // -> 0rem
+getLetterSpacing(-1, 0.6) // -> -1rem
+```
+
 ### Function - convertThemeToMaterial
 
 Converts a theme to a Material UI based theme. Intended to be used with [@input-output-hk/front-end-themes](https://npmjs.com/package/@input-output-hk/front-end-themes) themes to convert for usage with [@material-ui/core](https://npmjs.com/package/@material-ui/core).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@input-output-hk/front-end-core-libraries",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@input-output-hk/front-end-core-libraries",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@input-output-hk/front-end-core-libraries",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "IOHK front-end core libraries",
   "main": "build/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@input-output-hk/front-end-core-libraries",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "description": "IOHK front-end core libraries",
   "main": "build/index.js",
   "scripts": {

--- a/src/theme.js
+++ b/src/theme.js
@@ -7,11 +7,11 @@ export function getFontSize (fontSize, baseFontSize) {
     : `${baseFontSize / 10}rem`
 }
 
-export function getLetterSpacing (letterSpacing, baseLetterSpacing) {
-  if (typeof baseLetterSpacing !== 'number' || isNaN(baseLetterSpacing)) throw new Error('getLetterSpacing error, baseLetterSpacing must be a number')
+export function getLetterSpacing (letterSpacing, fallbackLetterSpacing) {
+  if (typeof fallbackLetterSpacing !== 'number' || isNaN(fallbackLetterSpacing)) throw new Error('getLetterSpacing error, fallbackLetterSpacing must be a number')
   return (typeof letterSpacing === 'number' && !isNaN(letterSpacing))
     ? `${letterSpacing}rem`
-    : `${baseLetterSpacing}rem`
+    : `${fallbackLetterSpacing}rem`
 }
 
 function getResponsiveFontConfig (font, baseFontSize) {

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,10 +1,17 @@
 import { createMuiTheme } from '@material-ui/core'
 
 export function getFontSize (fontSize, baseFontSize) {
-  if (typeof baseFontSize !== 'number' || baseFontSize <= 0) throw new Error('getFontSize error, baseFontSize must be a number greater than 0')
+  if (typeof baseFontSize !== 'number' || isNaN(baseFontSize) || baseFontSize <= 0) throw new Error('getFontSize error, baseFontSize must be a number greater than 0')
   return (fontSize && typeof fontSize === 'number' && fontSize > 0)
     ? `${baseFontSize * fontSize / 10}rem`
     : `${baseFontSize / 10}rem`
+}
+
+export function getLetterSpacing (letterSpacing, baseLetterSpacing) {
+  if (typeof baseLetterSpacing !== 'number' || isNaN(baseLetterSpacing)) throw new Error('getLetterSpacing error, baseLetterSpacing must be a number')
+  return (typeof letterSpacing === 'number' && !isNaN(letterSpacing))
+    ? `${letterSpacing}rem`
+    : `${baseLetterSpacing}rem`
 }
 
 function getResponsiveFontConfig (font, baseFontSize) {
@@ -49,51 +56,61 @@ export function convertThemeToMaterial (theme) {
       htmlFontSize: theme.typography.baseFontSize,
       h1: {
         ...theme.typography.h1,
+        letterSpacing: getLetterSpacing(theme.typography.h1.letterSpacing, theme.typography.letterSpacing),
         fontSize: getFontSize(theme.typography.h1.fontSize, theme.typography.baseFontSize),
         ...getResponsiveFontConfig(theme.typography.h1, theme.typography.baseFontSize)
       },
       h2: {
         ...theme.typography.h2,
+        letterSpacing: getLetterSpacing(theme.typography.h2.letterSpacing, theme.typography.letterSpacing),
         fontSize: getFontSize(theme.typography.h2.fontSize, theme.typography.baseFontSize),
         ...getResponsiveFontConfig(theme.typography.h2, theme.typography.baseFontSize)
       },
       h3: {
         ...theme.typography.h3,
+        letterSpacing: getLetterSpacing(theme.typography.h3.letterSpacing, theme.typography.letterSpacing),
         fontSize: getFontSize(theme.typography.h3.fontSize, theme.typography.baseFontSize),
         ...getResponsiveFontConfig(theme.typography.h3, theme.typography.baseFontSize)
       },
       h4: {
         ...theme.typography.h4,
+        letterSpacing: getLetterSpacing(theme.typography.h4.letterSpacing, theme.typography.letterSpacing),
         fontSize: getFontSize(theme.typography.h4.fontSize, theme.typography.baseFontSize),
         ...getResponsiveFontConfig(theme.typography.h4, theme.typography.baseFontSize)
       },
       h5: {
         ...theme.typography.h5,
+        letterSpacing: getLetterSpacing(theme.typography.h5.letterSpacing, theme.typography.letterSpacing),
         fontSize: getFontSize(theme.typography.h5.fontSize, theme.typography.baseFontSize),
         ...getResponsiveFontConfig(theme.typography.h5, theme.typography.baseFontSize)
       },
       h6: {
         ...theme.typography.h6,
+        letterSpacing: getLetterSpacing(theme.typography.h6.letterSpacing, theme.typography.letterSpacing),
         fontSize: getFontSize(theme.typography.h6.fontSize, theme.typography.baseFontSize),
         ...getResponsiveFontConfig(theme.typography.h6, theme.typography.baseFontSize)
       },
       body1: {
         ...theme.typography.body,
+        letterSpacing: getLetterSpacing(theme.typography.body.letterSpacing, theme.typography.letterSpacing),
         fontSize: getFontSize(theme.typography.body.fontSize, theme.typography.baseFontSize),
         ...getResponsiveFontConfig(theme.typography.body, theme.typography.baseFontSize)
       },
       body2: {
         ...theme.typography.body,
+        letterSpacing: getLetterSpacing(theme.typography.small.letterSpacing, theme.typography.letterSpacing),
         fontSize: getFontSize(theme.typography.small.fontSize, theme.typography.baseFontSize),
         ...getResponsiveFontConfig(theme.typography.small, theme.typography.baseFontSize)
       },
       button: {
         ...theme.typography.button,
+        letterSpacing: getLetterSpacing(theme.typography.button.letterSpacing, theme.typography.letterSpacing),
         fontSize: getFontSize(theme.typography.button.fontSize, theme.typography.baseFontSize),
         ...getResponsiveFontConfig(theme.typography.button, theme.typography.baseFontSize)
       },
       caption: {
         ...theme.typography.caption,
+        letterSpacing: getLetterSpacing(theme.typography.caption.letterSpacing, theme.typography.letterSpacing),
         fontSize: getFontSize(theme.typography.caption.fontSize, theme.typography.baseFontSize),
         ...getResponsiveFontConfig(theme.typography.caption, theme.typography.baseFontSize)
       }

--- a/src/theme.test.js
+++ b/src/theme.test.js
@@ -45,26 +45,26 @@ describe('getFontSize', () => {
 })
 
 describe('getLetterSpacing', () => {
-  describe('when baseLetterSpacing is not a number', () => {
-    test('when baseLetterSpacing is null an error is thrown', () => {
-      expect(() => getLetterSpacing(1, null)).toThrowError('getLetterSpacing error, baseLetterSpacing must be a number')
+  describe('when fallbackLetterSpacing is not a number', () => {
+    test('when fallbackLetterSpacing is null an error is thrown', () => {
+      expect(() => getLetterSpacing(1, null)).toThrowError('getLetterSpacing error, fallbackLetterSpacing must be a number')
     })
 
-    test('when baseLetterSpacing is NaN an error is thrown', () => {
-      expect(() => getLetterSpacing(1, NaN)).toThrowError('getLetterSpacing error, baseLetterSpacing must be a number')
+    test('when fallbackLetterSpacing is NaN an error is thrown', () => {
+      expect(() => getLetterSpacing(1, NaN)).toThrowError('getLetterSpacing error, fallbackLetterSpacing must be a number')
     })
   })
 
   describe('when letterSpacing is not a number', () => {
-    test('when letterSpacing is null the baseLetterSpacing value is used', () => {
+    test('when letterSpacing is null the fallbackLetterSpacing value is used', () => {
       expect(getLetterSpacing(null, -1)).toEqual('-1rem')
     })
 
-    test('when letterSpacing is NaN the baseLetterSpacing value is used', () => {
+    test('when letterSpacing is NaN the fallbackLetterSpacing value is used', () => {
       expect(getLetterSpacing(NaN, 0.4)).toEqual('0.4rem')
     })
 
-    test('when letterSpacing is undefined the baseLetterSpacing value is used', () => {
+    test('when letterSpacing is undefined the fallbackLetterSpacing value is used', () => {
       expect(getLetterSpacing(NaN, 0)).toEqual('0rem')
     })
   })

--- a/src/theme.test.js
+++ b/src/theme.test.js
@@ -1,4 +1,4 @@
-import { getFontSize } from './theme'
+import { getFontSize, getLetterSpacing } from './theme'
 
 describe('getFontSize', () => {
   describe('when fontSize > 0', () => {
@@ -41,5 +41,43 @@ describe('getFontSize', () => {
     test('it throws an error', () => {
       expect(() => getFontSize(null, 0)).toThrowError('getFontSize error, baseFontSize must be a number greater than 0')
     })
+  })
+})
+
+describe('getLetterSpacing', () => {
+  describe('when baseLetterSpacing is not a number', () => {
+    test('when baseLetterSpacing is null an error is thrown', () => {
+      expect(() => getLetterSpacing(1, null)).toThrowError('getLetterSpacing error, baseLetterSpacing must be a number')
+    })
+
+    test('when baseLetterSpacing is NaN an error is thrown', () => {
+      expect(() => getLetterSpacing(1, NaN)).toThrowError('getLetterSpacing error, baseLetterSpacing must be a number')
+    })
+  })
+
+  describe('when letterSpacing is not a number', () => {
+    test('when letterSpacing is null the baseLetterSpacing value is used', () => {
+      expect(getLetterSpacing(null, -1)).toEqual('-1rem')
+    })
+
+    test('when letterSpacing is NaN the baseLetterSpacing value is used', () => {
+      expect(getLetterSpacing(NaN, 0.4)).toEqual('0.4rem')
+    })
+
+    test('when letterSpacing is undefined the baseLetterSpacing value is used', () => {
+      expect(getLetterSpacing(NaN, 0)).toEqual('0rem')
+    })
+  })
+
+  test('when letterSpacing is -4 it returns -4rem', () => {
+    expect(getLetterSpacing(-4, 0.4)).toEqual('-4rem')
+  })
+
+  test('when letterSpacing is 0 it returns 0rem', () => {
+    expect(getLetterSpacing(0, 0.4)).toEqual('0rem')
+  })
+
+  test('when letterSpacing is 2.3 it returns 2.3rem', () => {
+    expect(getLetterSpacing(2.3, -0.6)).toEqual('2.3rem')
   })
 })


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Commit messages are concise and descriptive
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Removed any tech debt where applicable


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

* Converts letter spacing values from the theme into rem on a 1:1 scale.
* Exports conversion function for external use, intended to be used in [@input-output-hk/front-end-site-components](https://github.com/input-output-hk/front-end-site-components).

* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**: